### PR TITLE
change default livery name & version number

### DIFF
--- a/A330.acf
+++ b/A330.acf
@@ -38684,7 +38684,7 @@ P acf/_ann_wav_file/count 198
 P acf/_ap_crs_src 0
 P acf/_apt_req_plane 1
 P acf/_asi_is_kts 1
-P acf/_author AeroGenesisDevTeam
+P acf/_author AeroGenesis DevTeam
 P acf/_auto_engage_BC_deg 120.000000000
 P acf/_auto_omega_fire 0.000000000
 P acf/_auto_omega_idle 0.000000000
@@ -39738,7 +39738,7 @@ P acf/_cyclic_dn_trim_rat 0.000000000
 P acf/_cyclic_lf_trim_rat 0.000000000
 P acf/_cyclic_rt_trim_rat 0.000000000
 P acf/_cyclic_up_trim_rat 0.000000000
-P acf/_default_livery_name Lufthansa D-AIKN
+P acf/_default_livery_name AeroGenesis House
 P acf/_deg_psi_per_deg_def 10.000000000
 P acf/_deg_the_per_deg_def 6.000000000
 P acf/_delta3 0.000000000
@@ -40136,7 +40136,7 @@ P acf/_feathered_pitch 0.000000000
 P acf/_ff_rat_idle_JET 0.054000001
 P acf/_ff_rat_idle_PRP 0.100000001
 P acf/_ff_rat_idle_turbo 0.100000001
-P acf/_file_writer_version 122015
+P acf/_file_writer_version 122103
 P acf/_fixed_max/0 2E4
 P acf/_fixed_max/1 2E4
 P acf/_fixed_max/2 2E4
@@ -41061,7 +41061,7 @@ P acf/_tail_rot_with_v2_kts 0.000000000
 P acf/_tail_rotor_lf_trim_rat 0.000000000
 P acf/_tail_rotor_rt_trim_rat 0.000000000
 P acf/_tail_with_coll 0.000000000
-P acf/_tailnum D-AIKN
+P acf/_tailnum D-AGEN
 P acf/_tailrotor_EQ 0
 P acf/_takeoff_trim_11 -0.300000012
 P acf/_tank_name/0 Left Wing
@@ -41226,7 +41226,7 @@ P acf/_vect_min_nace 0.000000000
 P acf/_vect_power_aft 1.000000000
 P acf/_vect_power_for 1.000000000
 P acf/_vect_rate 15.000000000
-P acf/_version 1.1.1
+P acf/_version 1.2.0
 P acf/_vnav_descend_auto_arm 0
 P acf/_vor_mode_has_dead_reckon 1
 P acf/_vvi_but_adjusts_pitch 0

--- a/A330_GE_CF6.acf
+++ b/A330_GE_CF6.acf
@@ -38697,7 +38697,7 @@ P acf/_ann_wav_file/count 198
 P acf/_ap_crs_src 0
 P acf/_apt_req_plane 1
 P acf/_asi_is_kts 1
-P acf/_author AeroGenesisDevTeam
+P acf/_author AeroGenesis DevTeam
 P acf/_auto_engage_BC_deg 120.000000000
 P acf/_auto_omega_fire 0.000000000
 P acf/_auto_omega_idle 0.000000000
@@ -39751,7 +39751,7 @@ P acf/_cyclic_dn_trim_rat 0.000000000
 P acf/_cyclic_lf_trim_rat 0.000000000
 P acf/_cyclic_rt_trim_rat 0.000000000
 P acf/_cyclic_up_trim_rat 0.000000000
-P acf/_default_livery_name Lufthansa D-AIKN
+P acf/_default_livery_name AeroGenesis House
 P acf/_deg_psi_per_deg_def 10.000000000
 P acf/_deg_the_per_deg_def 6.000000000
 P acf/_delta3 0.000000000
@@ -40149,7 +40149,7 @@ P acf/_feathered_pitch 0.000000000
 P acf/_ff_rat_idle_JET 0.054000001
 P acf/_ff_rat_idle_PRP 0.100000001
 P acf/_ff_rat_idle_turbo 0.100000001
-P acf/_file_writer_version 122015
+P acf/_file_writer_version 122103
 P acf/_fixed_max/0 2E4
 P acf/_fixed_max/1 2E4
 P acf/_fixed_max/2 2E4
@@ -41074,7 +41074,7 @@ P acf/_tail_rot_with_v2_kts 0.000000000
 P acf/_tail_rotor_lf_trim_rat 0.000000000
 P acf/_tail_rotor_rt_trim_rat 0.000000000
 P acf/_tail_with_coll 0.000000000
-P acf/_tailnum D-AIKN
+P acf/_tailnum D-AGEN
 P acf/_tailrotor_EQ 0
 P acf/_takeoff_trim_11 -0.300000012
 P acf/_tank_name/0 Left Wing
@@ -41239,7 +41239,7 @@ P acf/_vect_min_nace 0.000000000
 P acf/_vect_power_aft 1.000000000
 P acf/_vect_power_for 1.000000000
 P acf/_vect_rate 15.000000000
-P acf/_version 1.1.1
+P acf/_version 1.2.0
 P acf/_vnav_descend_auto_arm 0
 P acf/_vor_mode_has_dead_reckon 1
 P acf/_vvi_but_adjusts_pitch 0

--- a/A330_PW4000.acf
+++ b/A330_PW4000.acf
@@ -38723,7 +38723,7 @@ P acf/_ann_wav_file/count 198
 P acf/_ap_crs_src 0
 P acf/_apt_req_plane 1
 P acf/_asi_is_kts 1
-P acf/_author AeroGenesisDevTeam
+P acf/_author AeroGenesis DevTeam
 P acf/_auto_engage_BC_deg 120.000000000
 P acf/_auto_omega_fire 0.000000000
 P acf/_auto_omega_idle 0.000000000
@@ -39777,7 +39777,7 @@ P acf/_cyclic_dn_trim_rat 0.000000000
 P acf/_cyclic_lf_trim_rat 0.000000000
 P acf/_cyclic_rt_trim_rat 0.000000000
 P acf/_cyclic_up_trim_rat 0.000000000
-P acf/_default_livery_name Lufthansa D-AIKN
+P acf/_default_livery_name AeroGenesis House
 P acf/_deg_psi_per_deg_def 10.000000000
 P acf/_deg_the_per_deg_def 6.000000000
 P acf/_delta3 0.000000000
@@ -40175,7 +40175,7 @@ P acf/_feathered_pitch 0.000000000
 P acf/_ff_rat_idle_JET 0.054000001
 P acf/_ff_rat_idle_PRP 0.100000001
 P acf/_ff_rat_idle_turbo 0.100000001
-P acf/_file_writer_version 122015
+P acf/_file_writer_version 122103
 P acf/_fixed_max/0 2E4
 P acf/_fixed_max/1 2E4
 P acf/_fixed_max/2 2E4
@@ -41100,7 +41100,7 @@ P acf/_tail_rot_with_v2_kts 0.000000000
 P acf/_tail_rotor_lf_trim_rat 0.000000000
 P acf/_tail_rotor_rt_trim_rat 0.000000000
 P acf/_tail_with_coll 0.000000000
-P acf/_tailnum D-AIKN
+P acf/_tailnum D-AGEN
 P acf/_tailrotor_EQ 0
 P acf/_takeoff_trim_11 -0.300000012
 P acf/_tank_name/0 Left Wing
@@ -41265,7 +41265,7 @@ P acf/_vect_min_nace 0.000000000
 P acf/_vect_power_aft 1.000000000
 P acf/_vect_power_for 1.000000000
 P acf/_vect_rate 15.000000000
-P acf/_version 1.1.1
+P acf/_version 1.2.0
 P acf/_vnav_descend_auto_arm 0
 P acf/_vor_mode_has_dead_reckon 1
 P acf/_vvi_but_adjusts_pitch 0


### PR DESCRIPTION
This changes the Name of the default livery shown in Aircraft selection menu & and the current version number (in this case 1.2.0 for next release)

Closes #49 
Closes #26 